### PR TITLE
Update Http.php to disable SSL verification

### DIFF
--- a/Splunk/Http.php
+++ b/Splunk/Http.php
@@ -105,6 +105,11 @@ class Splunk_Http
                 'max_redirects' => 0,       // [PHP 5.2] don't follow HTTP 3xx automatically
                 'ignore_errors' => TRUE,    // don't throw exceptions on bad status codes
             ),
+            'ssl' => array(
+                'verify_peer' => FALSE,      // disable SSL certificate validation
+                'verify_peer_name' => FALSE, // disable peer name verification
+                'allow_self_signed' => TRUE, // allow self signed certificates
+            ),
         ));
         
         // NOTE: PHP does not perform certificate validation for HTTPS URLs.


### PR DESCRIPTION
Splunk doesn't use CA signed SSL certificates by default and PHP behaviour for fopen changed in PHP 5.6.0 to verify SSL by default and this needs to be disabled, this relates to https://github.com/easylo/splunk-sdk/issues/1